### PR TITLE
Use env var for upload limit

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,10 +13,14 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
+
+const uploadLimit = Math.floor(Number(process.env.UPLOAD_LIMIT_MB) * 1024 * 1024);
+
 app.use(
   fileUpload({
     createParentPath: true,
-    limits: { fileSize: 50 * 1024 * 1024 }, // 50 MB
+    limits: { fileSize: uploadLimit },
+    abortOnLimit: true,
   })
 );
 

--- a/tests/uploadLimit.test.ts
+++ b/tests/uploadLimit.test.ts
@@ -1,0 +1,15 @@
+import request from 'supertest';
+import path from 'path';
+
+describe('file upload limit', () => {
+  it('rejects files larger than the configured limit', async () => {
+    jest.resetModules();
+    process.env.UPLOAD_LIMIT_MB = '0.0001';
+    const app = (await import('../src/app')).default;
+    const osmPath = path.join(__dirname, 'fixtures', 'sample.osm');
+    const res = await request(app)
+      .post('/api/network/upload-osm')
+      .attach('file', osmPath);
+    expect(res.status).toBe(413);
+  });
+});


### PR DESCRIPTION
## Summary
- load upload size limit from `process.env.UPLOAD_LIMIT_MB`
- enforce file size cap with `abortOnLimit`
- test upload size restriction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f9d14ef94832a9158ddd17fa7a989