### PR TITLE
Fix Jest test timeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.test.ts']
+  testMatch: ['**/tests/**/*.test.ts'],
+  // Increase timeout for slower environments
+  testTimeout: 10000
 };


### PR DESCRIPTION
## Summary
- configure Jest timeout to support slower environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fa02309b8832ab037685db7c2aa0b