### PR TITLE
Add new test cases and README for tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,18 @@
+# Pruebas
+
+Este directorio contiene las pruebas automáticas del proyecto.
+A continuación se describe brevemente qué cubre cada archivo:
+
+- **api.test.ts**: pruebas de integración de los endpoints principales. Comprueba
+  la respuesta de `/api/health`, la carga de archivos OSM y de puntos y la
+  ejecución del TSP.
+- **networkController.test.ts**: prueba unitaria de `processNetworkFile`,
+  asegurando que un JSON de red se transforma correctamente.
+- **uploadLimit.test.ts**: verifica que la configuración `UPLOAD_LIMIT_MB` limita
+  el tamaño permitido para subir archivos.
+- **osmParser.test.ts**: prueba de la utilidad `parseOSM` para extraer nodos y
+  aristas con distancia calculada desde un archivo OSM.
+- **pointsRoutes.test.ts**: comprueba que `/api/points/upload-points` devuelve un
+  error si no se ha cargado la malla antes.
+- **networkRoutesErrors.test.ts**: contiene casos de validación para
+  `/api/network/upload-osm` cuando no se envía archivo o está vacío.

--- a/tests/networkRoutesErrors.test.ts
+++ b/tests/networkRoutesErrors.test.ts
@@ -1,0 +1,19 @@
+import request from 'supertest';
+
+import app from '../src/app';
+
+describe('network upload validation', () => {
+  it('rejects missing file', async () => {
+    const res = await request(app).post('/api/network/upload-osm');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/archivo .osm requerido/i);
+  });
+
+  it('rejects empty file', async () => {
+    const res = await request(app)
+      .post('/api/network/upload-osm')
+      .attach('file', Buffer.from(''), 'empty.osm');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/vacion o malformado/i);
+  });
+});

--- a/tests/osmParser.test.ts
+++ b/tests/osmParser.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import { parseOSM } from '../src/utils/osmParser';
+
+describe('parseOSM utility', () => {
+  it('parses nodes and edges with distances', async () => {
+    const filePath = path.join(__dirname, 'fixtures', 'sample.osm');
+    const xml = fs.readFileSync(filePath, 'utf-8');
+    const { nodes, edges } = await parseOSM(xml);
+    expect(nodes).toHaveLength(4);
+    expect(edges).toHaveLength(6);
+    const e = edges.find(ed => ed.from === '1' && ed.to === '2');
+    expect(e).toBeDefined();
+    expect(e!.distance).toBeGreaterThan(111000);
+    expect(e!.distance).toBeLessThan(112000);
+  });
+});

--- a/tests/pointsRoutes.test.ts
+++ b/tests/pointsRoutes.test.ts
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import path from 'path';
+
+import app from '../src/app';
+import { setMesh } from '../src/services/meshService';
+import { setPoints } from '../src/services/pointsService';
+
+describe('points routes', () => {
+  beforeEach(() => {
+    setMesh([], []);
+    setPoints([]);
+  });
+
+  it('fails to upload points when no mesh is loaded', async () => {
+    const tsvPath = path.join(__dirname, 'fixtures', 'sample.tsv');
+    const res = await request(app)
+      .post('/api/points/upload-points')
+      .attach('file', tsvPath);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/No hay malla cargada/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add OSM parser unit tests
- validate network upload errors
- add points route error test
- document all available tests in `tests/README.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa4ebbe14832abd1b8d02c98c4ba8